### PR TITLE
Fix PEP517 build-system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 module = "nkdfu"


### PR DESCRIPTION
pyproject.toml:
Require `flit_core` instead of `flit` as `build-system.requires` and `flit_core.buildapi` instead of `flit.buildapi`, as described in the upstream flit documentation (https://flit.pypa.io/en/stable/). For the PEP517 based build process only `flit_core` is required.

@szszszsz it would be great if a new release could be cut after merging this, as it fixes the dependency resolution for downstreams.